### PR TITLE
🐛 Remove coupling of search/collides input geometry type to tree item geometry type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -5,9 +5,9 @@ declare class RBush<G extends Geometry, P extends GeoJsonProperties> {
     load(features: FeatureCollection<G, P> | Feature<G, P>[]): RBush<G, P>;
     remove(feature: Feature<G, P>, equals?: (a: Feature<G, P>, b: Feature<G, P>) => boolean): RBush<G, P>;
     clear(): RBush<G, P>;
-    search(geojson: Feature<G, P> | FeatureCollection<G, P> | BBox): FeatureCollection<G, P>;
+    search(geojson: Feature | FeatureCollection | BBox): FeatureCollection<G, P>;
     all(): FeatureCollection<any>;
-    collides(geosjon: Feature<G, P> | FeatureCollection<G, P> | BBox): boolean;
+    collides(geosjon: Feature | FeatureCollection | BBox): boolean;
     toJSON(): any;
     fromJSON(data: any): RBush<G, P>;
 }

--- a/types.ts
+++ b/types.ts
@@ -1,4 +1,4 @@
-import { point, polygon, featureCollection } from '@turf/helpers'
+import { point, polygon, featureCollection, Point, Polygon } from '@turf/helpers'
 import { BBox } from 'geojson'
 import rbush from './'
 
@@ -10,7 +10,7 @@ const poly = polygon([[[0, 0], [1, 1], [1, 1], [0, 0]]])
 const polygons = featureCollection([poly, poly])
 
 // Initialize GeoJSON RBush Tree
-const tree = rbush()
+const tree = rbush<Point | Polygon>()
 
 // Load Tree with a FeatureCollection
 tree.load(points);


### PR DESCRIPTION
TLDR:
This PR resolves a bug where if you pass a more specific Geometry type to the rbush constructor of the Features you will insert into the tree, like `new rbush<Point>()`, it is incorrectly enforcing that the geometry passed as input to the `search` and `collides` methods also be a Point, but it should be able to be a Polygon or any other valid Geometry.

Unblocks this PR - https://github.com/Turfjs/turf/pull/2225#discussion_r762602015

Background:
The geojson-rbush package, among other things, adda a generic type parameter to the rbush constructor, which by default enforces that the geometry type of items inserted into the rbush tree is a GeoJSON `Geometry`. 
```
declare class RBush<G extends Geometry, P extends GeoJsonProperties> {
```

Usually the default is fine.  But a generic parameter can be overridden, allowing you to specify a narrower Geometry type if you know for example that you will only insert type `Point` for example.  By doing this, when you use rbush methods to fetch items from your tree, you automatically get back tree items with the narrower geometry type you expect through the magic of Typescript generics, so that you don't have to cast.

To confirm this decoupling is valid, I can see that all that `geojson-rbush.search` does, it gets the bbox of your search geometry, and then calls rbush.search with that bbox.  Same for collides.  I think that the type of this input geometry to these two methods can/should be completely independent of the geometry type of items in the tree
```
    tree.search = function (geojson) {
        var features = rbush.prototype.search.call(this, this.toBBox(geojson));
        return featureCollection(features);
    };
```