### PR TITLE
Bump version to 3.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turf/geojson-rbush",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "GeoJSON implementation of RBush",
   "main": "index",
   "types": "index.d.ts",


### PR DESCRIPTION
In order to do a release we need to bump the version number. This moves it from `3.2.0` to `3.2.1`.